### PR TITLE
Change type to allow docs_url, redoc_url and openapi_url to be null

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -54,9 +54,9 @@ export type RouteParameter =
 export interface RouterOptions {
   base?: string
   schema?: Partial<OpenAPIObjectConfigV31 | OpenAPIObjectConfig>
-  docs_url?: string
-  redoc_url?: string
-  openapi_url?: string
+  docs_url?: string | null
+  redoc_url?: string | null
+  openapi_url?: string | null
   raiseUnknownParameters?: boolean
   generateOperationIds?: boolean
   openapiVersion?: '3' | '3.1'


### PR DESCRIPTION
According to the docs (and the code) these options should `null` to disable them:

```
Path for swagger docs, null: disabled, undefined: /docs
```

However in the type `null` is not allowd, causing VScode to complain when setting to `null` to disable.

<img width="444" alt="image" src="https://github.com/user-attachments/assets/13ee8454-a494-472b-acdd-9e80be4faf1c">
