### PR TITLE
Fix/Improve contentJson typing

### DIFF
--- a/src/contentTypes.ts
+++ b/src/contentTypes.ts
@@ -1,11 +1,20 @@
+import { z } from 'zod'
 import { legacyTypeIntoZod } from './zod/utils'
 
-export function contentJson(schema: any) {
-  return {
-    content: {
-      'application/json': {
-        schema: legacyTypeIntoZod(schema),
-      },
-    },
+type JsonContent<T> = {
+  content: {
+    'application/json': {
+      schema: z.ZodType<T>
+    }
   }
 }
+
+type InferSchemaType<T> = T extends z.ZodType ? z.infer<T> : T
+
+export const contentJson = <T>(schema: T): JsonContent<InferSchemaType<T>> => ({
+  content: {
+    'application/json': {
+      schema: schema instanceof z.ZodType ? schema : legacyTypeIntoZod(schema),
+    },
+  },
+})


### PR DESCRIPTION
Before:  contentJson with Zod schema or other have the typing `any`.
![image](https://github.com/user-attachments/assets/6c790844-264c-498c-a9a7-8ec2378faf0e)
![image](https://github.com/user-attachments/assets/8eec3412-5346-40b5-8272-671e3683185b)

After: contentJson with Zod schema and other have the right typing.
![image](https://github.com/user-attachments/assets/f8a747cd-f26d-4601-bcff-8054d3a5c5d8)
![image](https://github.com/user-attachments/assets/3a02bac0-6f4f-4dc5-b306-50fdecff8f39)

