### PR TITLE
suggested update to a Hono docs URL in the chanfana middleware docs

### DIFF
--- a/docs/pages/user-guide/middleware.md
+++ b/docs/pages/user-guide/middleware.md
@@ -1,4 +1,4 @@
 Middlewares are not handled by chanfana, please refer to your base router documentation for more information on this
 
-- [Hono Middlewares](https://hono.dev/docs/middleware/builtin/basic-auth)
+- [Hono Middlewares](https://hono.dev/docs/guides/middleware)
 - [itty-router Middlewares](https://itty.dev/itty-router/middleware/)


### PR DESCRIPTION
The current link takes you to the basic-auth builtin middleware when the link text implies it will go to middleware documentation in general.

For hono middleware in general, I suggest a better URL this could link to.