### PR TITLE
feat: Add typehinting for x-ignore in OpenAPI schema

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,7 @@
 # Command Line Interface (CLI)
 
 Chanfana provides a CLI tool to extract the OpenAPI schema from your Cloudflare Worker project. The `npx chanfana` command starts a local development server using `npx wrangler dev`, captures the server URL, fetches the OpenAPI schema from the `/openapi.json` endpoint, removes any paths marked with `x-ignore: true`, and writes the resulting schema to a file.
+The `x-ignore` property can be added to your `OpenAPIRouteSchema` for type-hinting.
 
 **Usage:**
 
@@ -30,7 +31,7 @@ This will:
 1. Run `npx wrangler dev` with any provided `wrangler` options in the current Worker project directory.
 2. Wait for the server to start and capture the first URL from the "ready on" message (e.g., `http://0.0.0.0:8788`).
 3. Fetch the OpenAPI schema from `<url>/openapi.json`.
-4. Remove any paths in the schema where any method (e.g., `get`, `post`) has `x-ignore: true`.
+4. Remove any paths in the schema where the `OpenAPIRouteSchema` for that path contains `x-ignore: true`.
 5. Write the modified schema to `schema.json` (or the file specified with `-o`) in the current working directory.
 6. Terminate the development server and exit.
 

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -12,6 +12,12 @@ export type OpenAPIRouterType<M> = {
   registry: OpenAPIRegistryMerger;
 };
 
+/**
+ * Handles the generation of OpenAPI schema and serves the documentation UI.
+ *
+ * Paths defined with `x-ignore: true` in their `OpenAPIRouteSchema`
+ * will be excluded from the generated OpenAPI specification by the CLI tool.
+ */
 export class OpenAPIHandler {
   router: any;
   options: RouterOptions;

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,6 +120,7 @@ export type OpenAPIRouteSchema = Simplify<
     responses?: {
       [statusCode: string]: ResponseConfig;
     };
+    "x-ignore"?: boolean;
   }
 >;
 


### PR DESCRIPTION
This commit introduces the `x-ignore` property to the `OpenAPIRouteSchema` type definition, allowing developers to get type hints when using this property to exclude paths from the OpenAPI schema generated by the CLI.

The documentation has been updated to reflect this change:
- `src/openapi.ts` now has JSDoc comments for the `OpenAPIHandler` class, explaining the `x-ignore` behavior.
- `docs/cli.md` has been updated to mention that `x-ignore` is a recognized property in `OpenAPIRouteSchema` and can be type-hinted.